### PR TITLE
Fix config imports and path setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The project provides two main entry points:
 
 ### Configuration
 
-Project settings, including file paths and handicapping parameters, can be configured in the `src/bris_handicapper/config/config.py` file.
+Project settings, including file paths and handicapping parameters, can be configured in the `src/config/config.py` file.
 
 ### Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 ]
 
 [tool.setuptools]
-packages = ["bris_handicapper"]
+packages = ["bris_handicapper", "config"]
 package-dir = {"" = "src"} # This tells setuptools to look in src/ for packages
 
 [project.scripts]

--- a/src/bris_handicapper/handicap.py
+++ b/src/bris_handicapper/handicap.py
@@ -13,10 +13,10 @@ from typing import Dict, Any, List, Optional
 import pandas as pd
 
 # --- Setup Project Root and System Path ---
-PROJECT_ROOT = Path(__file__).resolve().parent
-SRC_PATH = str(PROJECT_ROOT / "src")
-if SRC_PATH not in sys.path:
-    sys.path.insert(0, SRC_PATH)
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
 
 # --- Module Imports ---
 try:

--- a/src/bris_handicapper/main.py
+++ b/src/bris_handicapper/main.py
@@ -14,8 +14,10 @@ from datetime import datetime
 # --- Setup Project Root and System Path ---
 # This ensures that the 'src' directory is on the Python path, allowing
 # for absolute imports from modules within 'src'.
-PROJECT_ROOT = Path(__file__).resolve().parent
-sys.path.insert(0, str(PROJECT_ROOT / "src"))
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
 
 # --- Module Imports ---
 # Import the specific main functions and settings from our application structure.

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1,0 +1,8 @@
+from . import paths, settings, constants, data_mappings
+
+__all__ = [
+    "paths",
+    "settings",
+    "constants",
+    "data_mappings",
+]

--- a/src/config/data_mappings.py
+++ b/src/config/data_mappings.py
@@ -32,7 +32,7 @@ COLUMN_MAPPINGS = {
     "Today's_Medication": "medication_today",
     "Equipment_Change": "equipment_change_today",
     "BRIS_Run_Style_designation": "bris_run_style",
-    ""Quirin"_style_Speed_Points": "quirin_speed_points",
+    "\"Quirin\"_style_Speed_Points": "quirin_speed_points",
     "BRIS_Prime_Power_Rating": "bris_prime_power",
     "#_of_days_since_last_race": "days_since_last_race",
 


### PR DESCRIPTION
## Summary
- create `config/config.py` to expose settings modules
- package `config` in setuptools config
- fix sys.path setup in `main.py` and `handicap.py`
- update README with new config path
- fix quoting in data mappings

## Testing
- `python src/bris_handicapper/main.py`
- `python src/bris_handicapper/handicap.py` *(fails: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_6862c16f5084832591c17826248c7883