### PR TITLE
Fix missing config paths

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,6 +1,6 @@
 # BrisHandicapper/src/config/settings.py
 
-from .paths import RAW_DATA_DIR, PROCESSED_DATA_DIR
+from .paths import RAW_DATA_DIR, PROCESSED_DATA_DIR, PROJECT_ROOT
 
 # This file contains configuration settings used across the application,
 # particularly by the main pipeline script.
@@ -20,6 +20,23 @@ PROCESSED_DATA_DIR = PROCESSED_DATA_DIR
 CURRENT_RACE_INFO_FILE = PROCESSED_DATA_DIR / "current_race_info.parquet"
 PAST_STARTS_LONG_FILE = PROCESSED_DATA_DIR / "past_starts_long_format.parquet"
 WORKOUTS_LONG_FILE = PROCESSED_DATA_DIR / "workouts_long_format.parquet"
+
+# --- Cache Directory and Files ---
+# Directory for cached files like specification and dictionary data
+CACHE_DIR = PROJECT_ROOT / "cache"
+
+# Brisnet specification cache and dictionary paths
+BRIS_SPEC_CACHE = CACHE_DIR / "bris_spec.pkl"
+BRIS_DICT = CACHE_DIR / "bris_dict.txt"
+
+# --- Primary Processed Data File ---
+PARSED_RACE_DATA_FILE = PROCESSED_DATA_DIR / "parsed_race_data_full.parquet"
+
+# Aliases expected by data-processing modules
+PARSED_RACE_DATA = PARSED_RACE_DATA_FILE
+CURRENT_RACE_INFO = CURRENT_RACE_INFO_FILE
+PAST_STARTS_LONG = PAST_STARTS_LONG_FILE
+WORKOUTS_LONG = WORKOUTS_LONG_FILE
 
 
 # You can add other settings here as the project grows, such as model parameters,


### PR DESCRIPTION
## Summary
- add cache directory paths to config
- provide explicit processed data file paths and aliases

## Testing
- `python -m compileall -q src`
- `python src/bris_handicapper/main.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6862c828cc04832586922b6d2a50c2a1